### PR TITLE
Changed InitAsync to work without AsyncInitializer being present

### DIFF
--- a/src/AspNetCore.AsyncInitialization/Hosting/AsyncInitializationWebHostExtensions.cs
+++ b/src/AspNetCore.AsyncInitialization/Hosting/AsyncInitializationWebHostExtensions.cs
@@ -19,8 +19,11 @@ namespace Microsoft.AspNetCore.Hosting
         {
             using (var scope = host.Services.CreateScope())
             {
-                var initializer = scope.ServiceProvider.GetRequiredService<AsyncInitializer>();
-                await initializer.InitializeAsync();
+                var initializer = scope.ServiceProvider.GetService<AsyncInitializer>();
+                if (initializer != null)
+                {
+                    await initializer.InitializeAsync();
+                }
             }
         }
     }

--- a/tests/AspNetCore.AsyncInitialization.Tests/AsyncInitializationTests.cs
+++ b/tests/AspNetCore.AsyncInitialization.Tests/AsyncInitializationTests.cs
@@ -11,6 +11,14 @@ namespace AspNetCore.AsyncInitialization.Tests
     public class AsyncInitializationTests
     {
         [Fact]
+        public async Task InitAsync_without_initializer_works()
+        {
+            var host = CreateHost(_ => {});
+
+            await host.InitAsync();
+        }
+
+        [Fact]
         public async Task Single_initializer_is_called()
         {
             var initializer = A.Fake<IAsyncInitializer>();


### PR DESCRIPTION
This PR makes it so InitAsync does not fail when no AsyncInitializer is registered.
Since AddAsyncInitializer adds the AsyncInitializer service lazily it can be confusing when after removing the last AddAsyncInitializer call your Program.cs suddenly crashed on the InitAsync.