### PR TITLE
1. Added Initialization for IHost

### DIFF
--- a/src/AspNetCore.AsyncInitialization/AspNetCore.AsyncInitialization.csproj
+++ b/src/AspNetCore.AsyncInitialization/AspNetCore.AsyncInitialization.csproj
@@ -17,10 +17,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.0.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta-63127-02" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.1" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/src/AspNetCore.AsyncInitialization/Hosting/AsyncInitializationWebHostExtensions.cs
+++ b/src/AspNetCore.AsyncInitialization/Hosting/AsyncInitializationWebHostExtensions.cs
@@ -2,6 +2,7 @@ using System;
 using System.Threading.Tasks;
 using AspNetCore.AsyncInitialization;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 // ReSharper disable once CheckNamespace
 namespace Microsoft.AspNetCore.Hosting
@@ -18,16 +19,34 @@ namespace Microsoft.AspNetCore.Hosting
         /// <returns>A task that represents the initialization completion.</returns>
         public static async Task InitAsync(this IWebHost host)
         {
-            using (var scope = host.Services.CreateScope())
+            await Init(host.Services);
+        }
+        
+        /// <summary>
+        /// Initializes the application, by calling all registered async initializers.
+        /// </summary>
+        /// <param name="host">The web host.</param>
+        /// <returns>A task that represents the initialization completion.</returns>
+        public static async Task InitAsync(this IHost host)
+        {
+            await Init(host.Services);
+        }
+
+        private static async Task Init(IServiceProvider sp)
+        {
+            using (var scope = sp.CreateScope())
             {
                 var rootInitializer = scope.ServiceProvider.GetService<RootInitializer>();
                 if (rootInitializer == null)
                 {
-                    throw new InvalidOperationException("The async initialization service isn't registered, register it by calling AddAsyncInitialization() on the service collection or by adding an async initializer.");
+                    throw new InvalidOperationException(
+                        "The async initialization service isn't registered, register it by calling AddAsyncInitialization() on the service collection or by adding an async initializer.");
                 }
 
                 await rootInitializer.InitializeAsync();
             }
         }
+
+        
     }
 }

--- a/tests/AspNetCore.AsyncInitialization.Tests/AspNetCore.AsyncInitialization.Tests.csproj
+++ b/tests/AspNetCore.AsyncInitialization.Tests/AspNetCore.AsyncInitialization.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net471</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
Please include possibility for initialization of new .NET 6 Program.cs-styled startup.

```
var builder = WebApplication.CreateBuilder(args);
builder.Services.AddAsyncInitialization();


var app = builder.Build();
app.MapGet("/", () => "Hello World!");

//Problem here - new IHost interface
await app.InitAsync();

app.Run();
```